### PR TITLE
corrected the link to the basenames

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function Page() {
                 Looking a bit bare? 
               </motion.h1>
               <div className='flex flex-col items-center'>
-                <p className='text-center'> Go to <a href="https://base.or/names" target="_blank" rel="noreferrer" className=' hover:text-[#0052ff] hover:text-bold'>Basename</a> to add some details to your profile. <br /> Then see it everywhere. </p>
+                <p className='text-center'> Go to <a href="https://base.org/names" target="_blank" rel="noreferrer" className=' hover:text-[#0052ff] hover:text-bold'>Basename</a> to add some details to your profile. <br /> Then see it everywhere. </p>
               </div>
             </div>
           </>


### PR DESCRIPTION
Corrected the link to the basenames

**i've added the right link to basenames which is base.org/names , earlier it was base.or/names**

**i've tested the new link it's directing us to correct page**

<img width="1451" alt="Screenshot 2025-05-16 at 1 11 00 AM" src="https://github.com/user-attachments/assets/2f2917ad-5646-4b9e-b164-8f706820dc6d" />
